### PR TITLE
Rollback KIND_VERSION 1.21.2

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -6,4 +6,4 @@ kind delete cluster
 # clean up the local registry
 docker stop dev.local
 docker rm dev.local
-docker system prune
+docker system prune --volumes

--- a/kind-setup.sh
+++ b/kind-setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=${KIND_VERSION:-v1.21.9}
+version=${KIND_VERSION:-v1.21.2}
 clusters=$(kind get clusters)
 reg_name='dev.local'
 reg_port='5000'

--- a/kind-setup.sh
+++ b/kind-setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=${KIND_VERSION:-v1.22.5}
+version=${KIND_VERSION:-v1.21.9}
 clusters=$(kind get clusters)
 reg_name='dev.local'
 reg_port='5000'


### PR DESCRIPTION
Kindest node version of k8s is available for 1.21.x branch is 1.21.2: https://hub.docker.com/r/kindest/node/tags?page=1&name=1.21

Service binding issues with 1.22+ of k8s:
- https://github.com/vmware-labs/service-bindings/issues/214
- https://github.com/vmware-labs/service-bindings/pull/216