### PR TITLE
tap 1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.key
 tas-adapter-values.yml
 tap-values.yml
+tap-packages-*.tar.gz

--- a/developer-namespace.yml
+++ b/developer-namespace.yml
@@ -20,61 +20,25 @@ imagePullSecrets:
   - name: tap-registry
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: RoleBinding
 metadata:
-  name: default
-rules:
-- apiGroups: [source.toolkit.fluxcd.io]
-  resources: [gitrepositories]
-  verbs: ['*']
-- apiGroups: [source.apps.tanzu.vmware.com]
-  resources: [imagerepositories]
-  verbs: ['*']
-- apiGroups: [carto.run]
-  resources: [deliverables, runnables]
-  verbs: ['*']
-- apiGroups: [kpack.io]
-  resources: [images]
-  verbs: ['*']
-- apiGroups: [conventions.apps.tanzu.vmware.com]
-  resources: [podintents]
-  verbs: ['*']
-- apiGroups: [""]
-  resources: ['configmaps']
-  verbs: ['*']
-- apiGroups: [""]
-  resources: ['pods']
-  verbs: ['list']
-- apiGroups: [tekton.dev]
-  resources: [taskruns, pipelineruns]
-  verbs: ['*']
-- apiGroups: [tekton.dev]
-  resources: [pipelines]
-  verbs: ['list']
-- apiGroups: [kappctrl.k14s.io]
-  resources: [apps]
-  verbs: ['*']
-- apiGroups: [serving.knative.dev]
-  resources: ['services']
-  verbs: ['*']
-- apiGroups: [servicebinding.io]
-  resources: ['servicebindings']
-  verbs: ['*']
-- apiGroups: [services.apps.tanzu.vmware.com]
-  resources: ['resourceclaims']
-  verbs: ['*']
-- apiGroups: [scanning.apps.tanzu.vmware.com]
-  resources: ['imagescans', 'sourcescans']
-  verbs: ['*']
+  name: default-permit-deliverable
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: deliverable
+subjects:
+  - kind: ServiceAccount
+    name: default
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: default
+  name: default-permit-workload
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: default
+  kind: ClusterRole
+  name: workload
 subjects:
   - kind: ServiceAccount
     name: default

--- a/install.sh
+++ b/install.sh
@@ -11,8 +11,9 @@ docker inspect -f '{{.NetworkSettings.IPAddress}} dev.local' dev.local | (sudo t
 
 kubectl config use-context kind-${kind_cluster_name}
 
-./tanzu-cluster-essentials.sh ${tanzu_net_user} ${tanzu_net_pass}
 ./tanzu-cli.sh
+./tanzu-cluster-essentials.sh ${tanzu_net_user} ${tanzu_net_pass}
+./tanzu-relocate-images.sh ${tanzu_net_user} ${tanzu_net_pass}
 ./tanzu-application-platform.sh ${tanzu_net_user} ${tanzu_net_pass}
 ./developer-namespace.sh
-./tanzu-application-service-adapter.sh ${tanzu_net_user} ${tanzu_net_pass}
+# ./tanzu-application-service-adapter.sh ${tanzu_net_user} ${tanzu_net_pass}

--- a/kind-setup.sh
+++ b/kind-setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=${KIND_VERSION:-v1.21.2}
+version=${KIND_VERSION:-v1.23.4}
 clusters=$(kind get clusters)
 reg_name='dev.local'
 reg_port='5000'
@@ -13,8 +13,10 @@ function start_registry() {
 	running=$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)
 	if [ "${running}" != 'true' ]; then
 		docker run \
-			   -d --restart=always -p "${reg_port}:5000" --name "${reg_name}" \
-			   registry:2
+          #disable registry validation because some non-distributable images will fail when tanzu-relocate-images is executed
+          --env REGISTRY_VALIDATION_DISABLED=true \
+          -d --restart=always -p "${reg_port}:5000" --name "${reg_name}" \
+          registry:2
 	fi
 }
 

--- a/tanzu-application-platform.sh
+++ b/tanzu-application-platform.sh
@@ -2,11 +2,11 @@
 
 tanzu_net_user=$1
 tanzu_net_pass=$2
-version=${TAP_VERSION:-1.0.1}
+version=${TAP_VERSION:-1.1.0}
 
-export INSTALL_REGISTRY_USERNAME=${tanzu_net_user}
-export INSTALL_REGISTRY_PASSWORD=${tanzu_net_pass}
-export INSTALL_REGISTRY_HOSTNAME=registry.tanzu.vmware.com
+export INSTALL_REGISTRY_USERNAME=user
+export INSTALL_REGISTRY_PASSWORD=password
+export INSTALL_REGISTRY_HOSTNAME=dev.local:5000
 
 kubectl create namespace tap-install
 tanzu secret registry add tap-registry \
@@ -17,8 +17,16 @@ tanzu secret registry add tap-registry \
   --namespace tap-install \
   --yes
 
+tanzu secret registry add tanzunet-registry \
+  --username ${tanzu_net_user} \
+  --password ${tanzu_net_pass} \
+  --server registry.tanzu.vmware.com \
+  --export-to-all-namespaces \
+  --namespace tap-install \
+  --yes
+
 tanzu package repository add tanzu-tap-repository \
-  --url registry.tanzu.vmware.com/tanzu-application-platform/tap-packages:$version \
+  --url ${INSTALL_REGISTRY_HOSTNAME}/tanzu-application-platform/tap-packages:$version \
   --namespace tap-install
 
 tanzu package available list --namespace tap-install

--- a/tanzu-cli.sh
+++ b/tanzu-cli.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-version=${TANZU_APPLICATION_PLATFORM_VERSION:-1.0.1}
+version=${TANZU_APPLICATION_PLATFORM_VERSION:-1.1.0}
 glob=tanzu-framework-linux-amd64.tar
 
-# Based on: https://docs.vmware.com/en/Tanzu-Application-Platform/1.0/tap/GUID-install-general.html#update-prev-tap-tanzu-cli
+# Based on: https://docs.vmware.com/en/Tanzu-Application-Platform/1.1/tap/GUID-install-tanzu-cli.html
 
 rm -rf /tmp/tanzu-cli           # Remove previously downloaded cli files
 rm ~/scripts/tanzu              # Remove CLI binary (executable)

--- a/tanzu-cluster-essentials.sh
+++ b/tanzu-cluster-essentials.sh
@@ -2,7 +2,9 @@
 
 set +x
 
-version=${CLUSTER_ESSENTIALS_VERSION:-1.0.0}
+# Reference: https://docs.vmware.com/en/Cluster-Essentials-for-VMware-Tanzu/1.1/cluster-essentials/GUID-deploy.html
+
+version=${CLUSTER_ESSENTIALS_VERSION:-1.1.0}
 glob=${CLUSTER_ESSENTIALS_GLOB:-tanzu-cluster-essentials-linux-amd64-*.tgz}
 tanzu_net_user=$1
 tanzu_net_pass=$2
@@ -17,11 +19,15 @@ rm -fr /tmp/tanzu-cluster-essentials
 mkdir /tmp/tanzu-cluster-essentials
 cat /tmp/${glob} | tar -xvzf - -i -C /tmp/tanzu-cluster-essentials
 
-export INSTALL_BUNDLE=registry.tanzu.vmware.com/tanzu-cluster-essentials/cluster-essentials-bundle@sha256:82dfaf70656b54dcba0d4def85ccae1578ff27054e7533d08320244af7fb0343
+export INSTALL_BUNDLE=registry.tanzu.vmware.com/tanzu-cluster-essentials/cluster-essentials-bundle@sha256:ab0a3539da241a6ea59c75c0743e9058511d7c56312ea3906178ec0f3491f51d
 export INSTALL_REGISTRY_HOSTNAME=registry.tanzu.vmware.com
 export INSTALL_REGISTRY_USERNAME=${tanzu_net_user}
 export INSTALL_REGISTRY_PASSWORD=${tanzu_net_pass}
-cd /tmp/tanzu-cluster-essentials
-./install.sh
 
-cp /tmp/tanzu-cluster-essentials/kapp ~/scripts/kapp
+cd /tmp/tanzu-cluster-essentials
+./install.sh --yes
+
+install /tmp/tanzu-cluster-essentials/kapp ~/scripts/kapp
+install /tmp/tanzu-cluster-essentials/imgpkg ~/scripts/imgpkg
+install /tmp/tanzu-cluster-essentials/kbld ~/scripts/kbld
+install /tmp/tanzu-cluster-essentials/ytt ~/scripts/ytt

--- a/tanzu-relocate-images.sh
+++ b/tanzu-relocate-images.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Reference: https://docs.vmware.com/en/Tanzu-Application-Platform/1.1/tap/GUID-install.html#relocate-images-to-a-registry-0
+
+tanzu_net_user=$1
+tanzu_net_pass=$2
+version=${TAP_VERSION:-1.1.0}
+
+export INSTALL_REGISTRY_USERNAME=user
+export INSTALL_REGISTRY_PASSWORD=password
+export INSTALL_REGISTRY_HOSTNAME=localhost:5000
+export INSTALL_REGISTRY_REPOSITORY=tanzu-application-platform
+
+echo "Logging into ${INSTALL_REGISTRY_HOSTNAME} as ${INSTALL_REGISTRY_USERNAME}"
+docker login ${INSTALL_REGISTRY_HOSTNAME} --username ${INSTALL_REGISTRY_USERNAME} --password ${INSTALL_REGISTRY_PASSWORD}
+
+echo "Logging into registry.tanzu.vmware.com as ${tanzu_net_user}"
+docker login registry.tanzu.vmware.com --username ${tanzu_net_user} --password ${tanzu_net_pass}
+
+echo "Relocating tap-packages from registry.tanzu.vmware.com to ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REGISTRY_REPOSITORY}/tap-packages this can take up to 15 minutes"
+imgpkg copy \
+  --concurrency 32 \
+  --bundle registry.tanzu.vmware.com/tanzu-application-platform/tap-packages:${version} \
+  --to-tar tap-packages-${version}.tar.gz
+
+imgpkg copy \
+  --concurrency 32 \
+  --tar tap-packages-${version}.tar.gz \
+  --to-repo ${INSTALL_REGISTRY_HOSTNAME}/${INSTALL_REGISTRY_REPOSITORY}/tap-packages
+
+## Note that this might throw the following exception   UNKNOWN: unknown error; UNKNOWN: unknown error; map[]; MANIFEST_BLOB_UNKNOWN: blob unknown to registry; sha256:3a78847ea829208edc2d7b320b7e602b9d12e47689499d5180a9cc7790dec4d7 
+## If it does and you are using a local docker registry set the environment variable --env REGISTRY_VALIDATION_DISABLED=true when starting up the registry
+

--- a/tap-values-template.yml
+++ b/tap-values-template.yml
@@ -1,4 +1,4 @@
-profile: full
+profile: iterate
 ceip_policy_disclosed: true
 
 # https://docs.vmware.com/en/Tanzu-Application-Platform/1.0/tap/GUID-tanzu-build-service-install-tbs.html#install-tanzu-build-service-by-using-the-tanzu-cli-1
@@ -13,7 +13,7 @@ buildservice:
 supply_chain: basic
 
 cnrs:
-  domain_name: local.cernerpinzon.com
+  domain_name: 127-0-0-1.sslip.io
   provider: local
 
 ootb_supply_chain_basic:
@@ -26,10 +26,8 @@ ootb_supply_chain_basic:
 metadata_store: 
   app_service_type: NodePort
 
-excluded_packages:
-- tap-gui.tanzu.vmware.com
-- accelerator.apps.tanzu.vmware.com
-- build.appliveview.tanzu.vmware.com
-- run.appliveview.tanzu.vmware.com
-- learningcenter.tanzu.vmware.com
-- workshops.learningcenter.tanzu.vmware.com
+grype:
+  namespace: default
+  targetImagePullSecret: registry-credentials
+
+excluded_packages: []


### PR DESCRIPTION
- Update developer namespace to use new roles provided out of the box
- Update install.sh to relocate images to local registry
- Update registry to set env REGISTRY_VALIDATION_DISABLED=true; bump kind cluster version to 1.23.4
- Update tanzu-application-platform install to reference relocated images; still use tanzu net credentials for buildservice
- Bump tanzu-cli version to 1.1.0
- Update tanzu-cluster-essentials to update local system with kapp, imgpkg, kbld and ytt that ship with cluster essentials
- Update cluster essentials sha
- Added new script to relocate images from registry.tanzu.vmware.com to local registry
- Added tap-packages-*.tar.gz for images that have been downloaded locally for replication
- tap-values-template update to use iterate profile update cnrs domain_name to be 127-0-0-1.sslip.io add params for grype remove need for list of exculded_packages
